### PR TITLE
Adding the otterspace bagdes strategy

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -360,6 +360,7 @@ import * as arrowVesting from './arrow-vesting';
 import * as tutellusProtocol from './tutellus-protocol';
 import * as fightClub from './fight-club';
 import * as tproStaking from './tpro-staking';
+import * as otterspaceBadges from './otterspace-badges';
 
 const strategies = {
   'forta-shares': fortaShares,
@@ -723,7 +724,8 @@ const strategies = {
   'arrow-vesting': arrowVesting,
   'tutellus-protocol': tutellusProtocol,
   'fight-club': fightClub,
-  'tpro-staking': tproStaking
+  'tpro-staking': tproStaking,
+  'otterspace-badges': otterspaceBadges
 };
 
 Object.keys(strategies).forEach(function (strategyName) {

--- a/src/strategies/otterspace-badges/README.md
+++ b/src/strategies/otterspace-badges/README.md
@@ -1,14 +1,16 @@
 # Otterspace Badges
-* A RAFT is an NFT that represents a community (or a DAO) within Otterspace.
-* A RAFT has several badge specs under it. A badge spec is the design of a badge, which is essentially dscribed as ERC721 metadata standard.
-* Each BADGE is a non-transferable token built with [ERC4973]("https://github.com/otterspace-xyz/ERC4973") spec and maximally backwards compatible with ERC721. Each badge spec may have several badges associated which indicate the badges minted for that spec that is associated to a raft
 
-The parameters when using this strategy must specify
-* A RAFT token ID
-* The RAFT's contract address
-* An array of weights associated to the badge specs
+- A RAFT is an NFT that represents a community (or a DAO) within Otterspace.
+- A RAFT has several badge specs under it. A badge spec is the design of a badge, which is essentially described as ERC721 metadata standard.
+- Each BADGE is a non-transferable token built with [ERC4973]("https://github.com/otterspace-xyz/ERC4973") spec and maximally backwards compatible with ERC721. Each badge spec may have several badges associated which indicate the badges minted for that spec that is associated to a raft
 
-If no specs are specificed, all badges under the RAFT are considered equal with the weight of 1
+The parameters that must be specified when using this strategy are as follows
+
+- A RAFT token ID
+- The RAFT's contract address
+- An array of weights associated to the badge specs
+
+If no specs are specified, all badges under the RAFT are considered equal with the weight of 1
 
 Here is an example of its usage:
 

--- a/src/strategies/otterspace-badges/README.md
+++ b/src/strategies/otterspace-badges/README.md
@@ -1,16 +1,16 @@
 # Otterspace Badges
-* A RAFT is an NFT that represents a community(or a DAO) within Otterspace.
-* In order to mint a badge, it is defined with a badge spec, which is essentially dscribed as ERC721 metadata standard. A RAFT has several badge specs
+* A RAFT is an NFT that represents a community (or a DAO) within Otterspace.
+* A RAFT has several badge specs under it. A badge spec is the design of a badge, which is essentially dscribed as ERC721 metadata standard.
 * Each BADGE is a non-transferable token built with [ERC4973]("https://github.com/otterspace-xyz/ERC4973") spec and maximally backwards compatible with ERC721. Each badge spec may have several badges associated which indicate the badges minted for that spec that is associated to a raft
 
 The parameters when using this strategy must specify
-* A RAFT tokenId
+* A RAFT token ID
 * The RAFT's contract address
 * An array of weights associated to the badge specs
 
-If no specs are specifices, all badges under the RAFT are considered equal with the weight of 1
+If no specs are specificed, all badges under the RAFT are considered equal with the weight of 1
 
-Here is an example of it's usage:
+Here is an example of its usage:
 
 ```json
 {

--- a/src/strategies/otterspace-badges/README.md
+++ b/src/strategies/otterspace-badges/README.md
@@ -1,0 +1,31 @@
+# Otterspace Badges
+* A RAFT is an NFT that represents a community(or a DAO) within Otterspace.
+* In order to mint a badge, it is defined with a badge spec, which is essentially dscribed as ERC721 metadata standard. A RAFT has several badge specs
+* Each BADGE is a non-transferable token built with [ERC4973]("https://github.com/otterspace-xyz/ERC4973") spec and maximally backwards compatible with ERC721. Each badge spec may have several badges associated which indicate the badges minted for that spec that is associated to a raft
+
+The parameters when using this strategy must specify
+* A RAFT tokenId
+* The RAFT's contract address
+* An array of weights associated to the badge specs
+
+If no specs are specifices, all badges under the RAFT are considered equal with the weight of 1
+
+Here is an example of it's usage:
+
+```json
+{
+  "symbol": "BADGES",
+  "raftTokenId": "1",
+  "raftAddress": "0xbb8997048e5f0bfe6c9d6bee63ede53bd0236bb2",
+  "specs": [
+    {
+      "id": "bafyreicmofif36f2s4d2iv37gy532epnw7rwjf5rygdhzzh2iw6nmbunrq",
+      "weight": 5
+    },
+    {
+      "id": "bafyreihj2e3mxqwk24auglrfckk3eh2hzsq7eyghjpcprmopvok5wxz3bu",
+      "weight": 10
+    }
+  ]
+}
+```

--- a/src/strategies/otterspace-badges/examples.json
+++ b/src/strategies/otterspace-badges/examples.json
@@ -1,0 +1,49 @@
+[
+  {
+    "name": "Example query with specific badge specs",
+    "strategy": {
+      "name": "otterspace-badges",
+      "params": {
+        "symbol": "BADGES",
+        "raftTokenId": "1",
+        "raftAddress": "0xbb8997048e5f0bfe6c9d6bee63ede53bd0236bb2",
+        "specs": [
+          {
+            "id": "bafyreicmofif36f2s4d2iv37gy532epnw7rwjf5rygdhzzh2iw6nmbunrq",
+            "weight": 5
+          },
+          {
+            "id": "bafyreihj2e3mxqwk24auglrfckk3eh2hzsq7eyghjpcprmopvok5wxz3bu",
+            "weight": 10
+          }
+        ]
+      }
+    },
+    "network": "5",
+    "addresses": [
+      "0xbb9ecfd5685502977b5b7c1ac0cdff8c136a4da8",
+      "0x33d0bbd05cf3c7e040d33bc1f338585a087e5dd9",
+      "0x0F1c502d4EF5b1940a7A77062e51353D8B366547"
+    ],
+    "snapshot": 7456664
+  },
+  {
+    "name": "Example query for all badge specs",
+    "strategy": {
+      "name": "otterspace-badges",
+      "params": {
+        "symbol": "BADGES",
+        "raftTokenId": "1",
+        "raftAddress": "0xbb8997048e5f0bfe6c9d6bee63ede53bd0236bb2",
+        "specs": []
+      }
+    },
+    "network": "5",
+    "addresses": [
+      "0xbb9ecfd5685502977b5b7c1ac0cdff8c136a4da8",
+      "0x33d0bbd05cf3c7e040d33bc1f338585a087e5dd9",
+      "0x0F1c502d4EF5b1940a7A77062e51353D8B366547"
+    ],
+    "snapshot": 7456664
+  }
+]

--- a/src/strategies/otterspace-badges/index.ts
+++ b/src/strategies/otterspace-badges/index.ts
@@ -1,0 +1,80 @@
+import { subgraphRequest } from '../../utils';
+import examplesFile from './examples.json';
+
+export const author = 'otterspace';
+export const version = '1.0.0';
+export const examples = examplesFile;
+
+const OTTERSPACE_SUBGRAPH_API_URL = {
+  '5': 'https://api.thegraph.com/subgraphs/name/otterspace-xyz/badges-goerli'
+};
+
+const params = {
+  badges: {
+    __args: {
+      where: {
+        spec_: {
+          raft: ''
+        }
+      }
+    },
+    owner: true,
+    spec: {
+      id: true
+    }
+  }
+};
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  snapshot
+) {
+  // Get all the badges for a raft
+  params.badges.__args.where.spec_.raft = `${options.raftAddress}:${options.raftTokenId}`;
+  const getBadgesResponse = await subgraphRequest(
+    OTTERSPACE_SUBGRAPH_API_URL[network],
+    params
+  );
+
+  // If a badge's spec is listed in the options, set the associated weight
+  const badgeWeights = {};
+  if (getBadgesResponse && getBadgesResponse.badges) {
+    getBadgesResponse.badges.forEach((badge: any) => {
+      const badgeAddress = badge.owner.toLowerCase();
+
+      // set the weight of a badge as 0
+      let badgeWeight = badgeWeights[badgeAddress];
+      if (!badgeWeight) {
+        badgeWeight = 0;
+      } else {
+        return;
+      }
+
+      if (options.specs && options.specs.length > 0) {
+        // for the specs defined in config, set the associated weight
+        const specConfig = options.specs.find(
+          (s: any) => s.id === badge.spec.id
+        );
+        badgeWeight = specConfig !== undefined ? specConfig.weight : 0;
+      } else {
+        // if there were no specs sepcified, all badges under the raft
+        // are treated as equally weighted
+        badgeWeight = 1;
+      }
+      badgeWeights[badgeAddress] = badgeWeight;
+    });
+  }
+
+  // For all the addresses that vote with a badge, perform a lookup to fetch their associated weight
+  return Object.fromEntries(
+    addresses.map((address: any) => [
+      address,
+      badgeWeights[address.toLowerCase()] || 0
+    ])
+  );
+}

--- a/src/strategies/otterspace-badges/index.ts
+++ b/src/strategies/otterspace-badges/index.ts
@@ -6,6 +6,7 @@ export const version = '1.0.0';
 export const examples = examplesFile;
 
 const OTTERSPACE_SUBGRAPH_API_URL = {
+  '1': 'https://api.thegraph.com/subgraphs/name/otterspace-xyz/badges-optimism',
   '5': 'https://api.thegraph.com/subgraphs/name/otterspace-xyz/badges-goerli'
 };
 


### PR DESCRIPTION
cc @grp06 @firatkaratas @stefan-girlich please review this PR

--

Some raw relevant notes from snapshot team

> Hi @rsquare! The voting strategies resolve voting power for multiple addresses at once, if you want make voting power based on NFT attribute(s) you need to way to query those attributes for multiple addresses in an efficient way. Doing this directly with a node and IPFS gateway take too much requests and doesnt scale. What I recommend is to create a subgraph that store these informations (which address hold which NFT attribute) and from this you can make a custom voting strategy that resolve voting power in just few requests.
> 
> Subgraph are on Optimism we use subgraph there for others things like delegation. But if you like you can use your own API too or another solution, the only requirement is that you can calculate the voting power at a specific time or block number, having an API with just the voting power is not enough


--

Goal: Create a snapshot strategy for DAOs so that they can create governance proposals where badge holders can vote in a 1 badge = 1 vote manner. Also provide option to speficy varying degrees of influence across various sub-daos or different teams/guilds i.e., specified via a badge spec. 

Solution: A custom snapshot strategy that will talk to our subgraph API

--

Basically, in snapshot, when a vote is cast it is associated with "weights" to compute a "score" for that vote. 

So for DAOs for exampl, we can configure all core contribs have a weight of 100 vs Members havign a weight of 1. When no weights are specified, I made the logic to be that all token are then equal with a weight of 1. 

When setting up the snapshot prroposal, a user is presented an option to select a strategy. Upon selecting, u have to provide a "configuration", which is what is in the example file.
![image](https://user-images.githubusercontent.com/1197049/187246972-6c4a81d2-bbd8-4550-aa75-e12908d7e720.png)
